### PR TITLE
Change Date management in scheduler

### DIFF
--- a/eisenhower-matrix/pom.xml
+++ b/eisenhower-matrix/pom.xml
@@ -31,6 +31,11 @@
       <artifactId>gson</artifactId>
       <version>2.8.6</version>
     </dependency>
+    <dependency>
+      <groupId>com.google.apis</groupId>
+      <artifactId>google-api-services-calendar</artifactId>
+      <version>v3-rev411-1.25.0</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/eisenhower-matrix/src/main/java/com/google/sps/classes/Scheduler.java
+++ b/eisenhower-matrix/src/main/java/com/google/sps/classes/Scheduler.java
@@ -18,37 +18,38 @@ public class Scheduler {
         Collections.sort(tasks, Task.ORDER_BY_CATEGORY.thenComparing(Task.ORDER_BY_DUEDATE));
 
         // Starting Date to create time blocks
-        // We are scheduling for the next day starting from 8AM and ending at 8PM
-        Date currStartingDate;
+        Date timeBlockDate;
 
-        LocalDateTime currStartingTime = LocalDateTime.now();
+        LocalDateTime blockStartTime = LocalDateTime.now();
         //Sets the calendar instance to 8AM in the next day
-        currStartingTime = currStartingTime.plusDays(1);
-        currStartingTime = currStartingTime.withHour(8);
-        currStartingTime = currStartingTime.withMinute(0);
+        blockStartTime = blockStartTime.plusDays(1);
+        blockStartTime = blockStartTime.withHour(8);
+        blockStartTime = blockStartTime.withMinute(0);
         
         
         Collection<TimeBlock> taskSchedule = new ArrayList<TimeBlock> ();
 
+        // Schedules each task for the next day starting from 8AM and ending at 8PM, rolling
+        // over to additional days if needed
         for (Task t : tasks) {
             //Checks if we need to schedule the rest of the tasks today
-            LocalDateTime endingTime = currStartingTime.plusMinutes(t.getDuration());
+            LocalDateTime blockEndTime = blockStartTime.plusMinutes(t.getDuration());
 
             //Prevents scheduling tasks past 8PM unless the task itself is longer 
             //than 12 hours.
-            if (endingTime.getHour() < 20 && t.getDuration() < 720) {
-                currStartingTime = currStartingTime.plusDays(1);
-                currStartingTime = currStartingTime.withHour(8);
-                currStartingTime = currStartingTime.withMinute(0);
+            if (blockEndTime.getHour() < 20 && t.getDuration() < 720) {
+                blockStartTime = blockStartTime.plusDays(1);
+                blockStartTime = blockStartTime.withHour(8);
+                blockStartTime = blockStartTime.withMinute(0);
             } 
 
             //Creates and adds a new time block for the task 
-            currStartingDate = Date.from(currStartingTime.atZone(ZoneId.systemDefault()).toInstant());
-            TimeBlock newBlock = new TimeBlock(t, currStartingDate, null);
+            timeBlockDate = Date.from(blockStartTime.atZone(ZoneId.systemDefault()).toInstant());
+            TimeBlock newBlock = new TimeBlock(t,timeBlockDate, null);
             taskSchedule.add(newBlock);
 
             //Updates the starting date for the next time block
-            currStartingTime = currStartingTime.plusMinutes(1);
+            blockStartTime = blockStartTime.plusMinutes(1);
         }
 
         return taskSchedule;

--- a/eisenhower-matrix/src/main/java/com/google/sps/classes/Scheduler.java
+++ b/eisenhower-matrix/src/main/java/com/google/sps/classes/Scheduler.java
@@ -1,11 +1,15 @@
 package com.google.sps.classes;
 
-import java.util.Calendar;
+
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Collections;
 import java.util.Collection;
 import java.util.Date;
 import java.util.ArrayList;
 import java.util.List;
+
 
 public class Scheduler {
     
@@ -14,37 +18,37 @@ public class Scheduler {
         Collections.sort(tasks, Task.ORDER_BY_CATEGORY.thenComparing(Task.ORDER_BY_DUEDATE));
 
         // Starting Date to create time blocks
-        //We are scheduling for the next day starting from 8AM and ending at 8PM
-        Calendar cal = Calendar.getInstance();
+        // We are scheduling for the next day starting from 8AM and ending at 8PM
+        Date currStartingDate;
+
+        LocalDateTime currStartingTime = LocalDateTime.now();
         //Sets the calendar instance to 8AM in the next day
-        cal.add(Calendar.DATE, 1);
-        cal.set(Calendar.HOUR_OF_DAY, 8);
-        cal.set(Calendar.MINUTE, 0);
-        Date currStartingDate = cal.getTime();
+        currStartingTime = currStartingTime.plusDays(1);
+        currStartingTime = currStartingTime.withHour(8);
+        currStartingTime = currStartingTime.withMinute(0);
+        
         
         Collection<TimeBlock> taskSchedule = new ArrayList<TimeBlock> ();
 
         for (Task t : tasks) {
             //Checks if we need to schedule the rest of the tasks today
-            Calendar endingCal = (Calendar)cal.clone();
-            endingCal.add(Calendar.MINUTE, t.getDuration());
+            LocalDateTime endingTime = currStartingTime.plusMinutes(t.getDuration());
+
             //Prevents scheduling tasks past 8PM unless the task itself is longer 
             //than 12 hours.
-            if (endingCal.get(Calendar.HOUR_OF_DAY) < 20 && t.getDuration() < 720) {
-                cal.add(Calendar.DATE, 1);
-                cal.set(Calendar.HOUR_OF_DAY, 8);
-                cal.set(Calendar.MINUTE, 0);
-                currStartingDate = cal.getTime();
+            if (endingTime.getHour() < 20 && t.getDuration() < 720) {
+                currStartingTime = currStartingTime.plusDays(1);
+                currStartingTime = currStartingTime.withHour(8);
+                currStartingTime = currStartingTime.withMinute(0);
             } 
 
             //Creates and adds a new time block for the task 
+            currStartingDate = Date.from(currStartingTime.atZone(ZoneId.systemDefault()).toInstant());
             TimeBlock newBlock = new TimeBlock(t, currStartingDate, null);
             taskSchedule.add(newBlock);
 
             //Updates the starting date for the next time block
-            cal.setTime(newBlock.getEnd());
-            cal.add(Calendar.MINUTE, 1);
-            currStartingDate = cal.getTime();
+            currStartingTime = currStartingTime.plusMinutes(1);
         }
 
         return taskSchedule;

--- a/eisenhower-matrix/src/main/java/com/google/sps/classes/Task.java
+++ b/eisenhower-matrix/src/main/java/com/google/sps/classes/Task.java
@@ -1,5 +1,7 @@
 package com.google.sps.classes;
 
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Date;
 import java.util.Comparator;
 
@@ -81,6 +83,16 @@ public class Task {
     */
     public Date getDueDate() {
         return this.dueDate;
+    }
+
+    /**
+    * Converts the task due date to LocalDateTime format
+    * Used for Scheduler algorithm
+    */
+    public LocalDateTime getLDDueDate() {
+        return dueDate.toInstant()
+      .atZone(ZoneId.systemDefault())
+      .toLocalDateTime();
     }
 
     /**


### PR DESCRIPTION
In order to integrate the Google Calendar API, the `java.util.Calendar` needed to be replaced since it's name conflicted. I replaced it with the `LocalDateTime` class, but did not change any inherent characteristics of the `Task` and `TimeBlock` classes so that we wouldn't have to make significant changes to existing work.